### PR TITLE
Fix the situation where the state machine cannot stop

### DIFF
--- a/box/meta/machine.go
+++ b/box/meta/machine.go
@@ -127,9 +127,9 @@ func (sm *StateMachine[T]) MoveToState(s T) bool {
 		return false
 	}
 
-	if sm.trace {
-		log.Debugf("state machine [%s] move state from %v to %v", sm.name, sm.GetState(), s)
-	}
+	//if sm.trace {
+	log.Debugf("state machine [%s] move state from %v to %v", sm.name, sm.GetState(), s)
+	//}
 	//else {
 	//	log.Tracef("state machine [%s] move state from %v to %v", sm.name, sm.current, s)
 	//}

--- a/box/meta/machine_test.go
+++ b/box/meta/machine_test.go
@@ -1,34 +1,105 @@
 package meta
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func onStarting(args interface{}) {
-	//
+func newTestMachine(precision time.Duration) *StateMachine[string] {
+	return NewStateMachine[string]("test machine", precision)
 }
 
-func onStopping(args interface{}) {
-	//
+func noop(args any) {}
+
+func TestStateMachineStartupRequiresRegisteredStates(t *testing.T) {
+	sm := newTestMachine(time.Millisecond * 5)
+	assert.False(t, sm.Startup())
 }
 
-func TestNewStateMachine(t *testing.T) {
-	sm := NewStateMachine("test machine", time.Millisecond*100)
-	assert.NotNil(t, sm)
+func TestStateMachineStartupFailsWithoutStartingState(t *testing.T) {
+	sm := newTestMachine(time.Millisecond * 5)
+	assert.True(t, sm.RegisterState(&State[string]{Name: "running", Action: noop}))
+	assert.True(t, sm.RegisterState(&State[string]{Name: "stopping", Action: noop}))
+	assert.True(t, sm.SetStoppingState("stopping"))
+	assert.False(t, sm.Startup())
+}
 
-	sm.RegisterStates([]*State{
-		{Name: "starting", Action: onStarting},
-		{Name: "stopping", Action: onStopping},
-	})
+func TestStateMachineMoveToStateResetsTickCounter(t *testing.T) {
+	sm := newTestMachine(time.Millisecond * 5)
+	delayed := &State[string]{Name: "delayed", Ticks: 3, Action: noop}
+	other := &State[string]{Name: "other", Action: noop}
+	assert.True(t, sm.RegisterState(delayed))
+	assert.True(t, sm.RegisterState(other))
+	assert.True(t, sm.MoveToState("delayed"))
+	delayed.trigger()
+	assert.Equal(t, uint(1), delayed.tickCnt)
+	assert.True(t, sm.MoveToState("other"))
+	assert.True(t, sm.MoveToState("delayed"))
+	assert.Equal(t, uint(0), delayed.tickCnt)
+}
 
-	sm.SetStartingState("starting")
-	sm.SetStoppingState("stopping")
-
-	sm.Startup()
-
-	time.Sleep(time.Second * 10)
-
+func TestStateMachineShutdownIsIdempotentAndRestartable(t *testing.T) {
+	sm := newTestMachine(time.Millisecond * 5)
+	started := make(chan struct{}, 1)
+	running := &State[string]{
+		Name: "running",
+		Action: func(args interface{}) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+		},
+	}
+	stopping := &State[string]{Name: "stopping", Action: noop}
+	assert.True(t, sm.RegisterStates([]*State[string]{running, stopping}))
+	assert.True(t, sm.Startup())
+	select {
+	case <-started:
+	case <-time.After(time.Millisecond * 50):
+		t.Fatal("running action never triggered")
+	}
+	assert.NotPanics(t, func() { sm.Shutdown() })
+	assert.NotPanics(t, func() { sm.Shutdown() })
+	assert.True(t, sm.Startup())
+	time.Sleep(time.Millisecond * 20)
 	sm.Shutdown()
+}
+
+func TestStateMachineExecutesActionsAndStops(t *testing.T) {
+	sm := newTestMachine(time.Millisecond * 5)
+	startHits := make(chan struct{}, 1)
+	stopHits := make(chan struct{}, 1)
+	starting := &State[string]{
+		Name: "starting",
+		Action: func(args interface{}) {
+			select {
+			case startHits <- struct{}{}:
+			default:
+			}
+		},
+	}
+	stopping := &State[string]{
+		Name: "stopping",
+		Action: func(args interface{}) {
+			select {
+			case stopHits <- struct{}{}:
+			default:
+			}
+		},
+	}
+	assert.True(t, sm.RegisterStates([]*State[string]{starting, stopping}))
+	assert.True(t, sm.Startup())
+	select {
+	case <-startHits:
+	case <-time.After(time.Millisecond * 50):
+		t.Fatal("starting action never triggered")
+	}
+	sm.Shutdown()
+	select {
+	case <-stopHits:
+	case <-time.After(time.Millisecond * 50):
+		t.Fatal("stopping action never triggered")
+	}
 }


### PR DESCRIPTION
If a callback function is triggered simultaneously when calling the Shutdown function, and there is a time-consuming task in the callback function and the state is migrated to a non stopping state. This will cause the state machine state to never point to stopping, resulting in the Shutdown function being unable to exit